### PR TITLE
payer_account added to bill

### DIFF
--- a/server/code/models/bill.py
+++ b/server/code/models/bill.py
@@ -12,16 +12,18 @@ class BillModel(db.Model):
     cash = db.Column(db.Float(precision=2), default=0)
     description = db.Column(db.String(100))
     is_payed = db.Column(db.Boolean, default=0)     # 0 means not payed
+    payer_account = db.Column(db.String(28), default="")
 
     category_id = db.Column(db.Integer, db.ForeignKey('bill_categories.id'))
     category = db.relationship('BillCategoryModel')
 
-    def __init__(self, usage, cash, description, category_id, is_payed=0):
+    def __init__(self, usage, cash, description, category_id,  payer_account="", is_payed=0,):
         self.usage = usage
         self.cash = cash
         self.description = description
         self.category_id = category_id
         self.is_payed = is_payed
+        self.payer_account = payer_account
 
     def json(self):
         #TODO zwroc id rachunku, co by mozna bylo usuwac dowolny
@@ -32,6 +34,7 @@ class BillModel(db.Model):
                 'cash': self.cash,
                 'date': date[:10],
                 'is_payed': self.is_payed,
+                'payer_account': self.payer_account,
                 'description': self.description
                 }
 


### PR DESCRIPTION
if you pass "" (or nothing) to POST bill , it will automatically insert currently logged users bank_account to "payer_account" field
You can also do POST /bill
{...
"payer_account": "PL213834123666"
...
}
and it will insert it as it should, instead of current users bank account.